### PR TITLE
Add tf2_sensor_msgs to build dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ find_package(sensor_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2_geometry_msgs  REQUIRED)
+find_package(tf2_sensor_msgs  REQUIRED)
 find_package(tf2_eigen REQUIRED)
 find_package(pcl_conversions REQUIRED)
 find_package(PCL REQUIRED)
@@ -37,6 +38,7 @@ ament_target_dependencies(pcl_localization_component
   rclcpp  
   tf2_ros 
   tf2_geometry_msgs 
+  tf2_sensor_msgs
   tf2_eigen 
   geometry_msgs 
   sensor_msgs


### PR DESCRIPTION
Hello,

I tried building this package in ros2 humble, and I encountered a build issue as follows:

```sh
pcl_localization_ros2/include/pcl_localization/pcl_localization_component.hpp:17:10: fatal error: tf2_sensor_msgs/tf2_sensor_msgs.h: No such file or directory
604 17 | #include <tf2_sensor_msgs/tf2_sensor_msgs.h>
605    |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
606 compilation terminated.
```

This issue was consistent on both the main and humble branches. As a result, I have submitted a pull request with the necessary fixes.

Best regards